### PR TITLE
Change definition to foundry 9+

### DIFF
--- a/module.json
+++ b/module.json
@@ -24,7 +24,7 @@
       "path": "packs/macros.db",
       "system": "rqg",
       "package": "rqg-babele-es",
-      "entity": "Macro",
+      "type": "Macro",
       "private": false,
       "absPath": "packs/macros.db"
     }


### PR DESCRIPTION
In Foundry 9 the name for `entity` changed to `type`. In Foundry 10 I think they will remove the support for `entity` so changing this will remove support for Foundry 8, but will work in Foundry 9 and onwards.

There currently is a warning when using this module:
```
FoundryVTT | 2022-03-18 23:29:40 | [warn] Package rqg-babele-es contains 1 compendium definitions that still use the deprecated 'entity' field instead of 'type'
```